### PR TITLE
Remove margin to remove overflow on main page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,7 @@ body {
   min-height: 100vh;
   height: auto;
   letter-spacing: 0.1em;
+  margin: 0;
 }
 
 h1,h2,h4,p {


### PR DESCRIPTION
Your page currently has a bit of [unnecessary y-overflow](https://i.imgur.com/wfNxfIN.jpg) when viewed on a device with a large enough viewport to display all of the pages content, causing a scrollbar to appear.

This fixes it :)